### PR TITLE
Add fseek() stream support

### DIFF
--- a/src/MockPhpStream.php
+++ b/src/MockPhpStream.php
@@ -105,8 +105,27 @@ class MockPhpStream
 		}
 	}
 
-	public function stream_seek($offset, $whence = SEEK_SET)
-	{
-	}
+    /**
+     * stream_seek method mock implementation
+     * just returns seek success response - that's enough for basic tests
+     * stream position pointer moving is not implemented
+     * @param $offset
+     * @param int $whence
+     * @return bool
+     */
+    public function stream_seek($offset, $whence = SEEK_SET)
+    {
+        return true;
+    }
+
+    /**
+     * stream_tell method mock implementation
+     * requred for testing code that uses fseek() on mocked stream
+     * @return int
+     */
+    public function stream_tell()
+    {
+        return $this->index;
+    }
 
 }


### PR DESCRIPTION
When testing code that uses `fseek()` on mocked stream it is necessary to have `stream_seek` and `stream_tell` methods. The latter is used by `fseek()` to get the current position in stream after seeking. 

For basic tests it is enough to implement `stream_seek` just returning true which means seek success response - without any stream position arithmetics.
