### PR TITLE
Do not save 'php://temp' to avoid artefacts appears on multiple temp open

### DIFF
--- a/src/MockPhpStream.php
+++ b/src/MockPhpStream.php
@@ -100,7 +100,9 @@ class MockPhpStream
 	{
 		if (!empty($this->content)) {
 			if (isset(self::$data)) {
-				self::$data[$this->path] = $this->content;
+				if ($this->path !== 'php://temp') {
+					self::$data[$this->path] = $this->content;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hello,

Thanks for a cool tool!

Trying to mock php://input to create mocked PSR-7/ServerRequest (Guzzle implementation) object I found that each one separate test works while several tests in a row fails. After going deep, I found that the problem was persistance of php://temp. It is as well persistant as any other php://??? mocked file while applications rely on it is empty on open. Also I found that the content persistent even stream handler restored.

There was two options:
1. Clear static $data on restore
2. Do not save stream data if it is temp stream.

As for me, the second option match natural temp stream behavior better.

So here is a simple patch to fix this, just do not save to static 'temp' stream.
